### PR TITLE
CI run every wednesday instead of everyday

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ on:
     branches:
       - main
   schedule:
-    # Run every day at 7:42am UTC.
-    - cron:  '42 7 * * *'
+    # Run wednesday at 7:42am UTC.
+    - cron:  '42 8 * * wed'
 
 jobs:
   benchopt_dev:


### PR DESCRIPTION
Changes conforming to this [PR](https://github.com/benchopt/benchmark_logreg_l2/pull/53) in core Benchopt.